### PR TITLE
Add clear method, delegate, and improve UI feedback

### DIFF
--- a/AutoTest.Desktop/Pages/OptionForPage/CreateOptionPage.xaml.cs
+++ b/AutoTest.Desktop/Pages/OptionForPage/CreateOptionPage.xaml.cs
@@ -58,8 +58,14 @@ namespace AutoTest.Desktop.Pages.OptionForPage
                 return new List<OptionDto>();
         }
 
+        private void Clear()
+        {
+            txtName.Clear();
+            rbIsCorrect.IsChecked = false;
+        }
         private void AddOptionBtn_Click(object sender, RoutedEventArgs e)
         {
+            EmptyData.Visibility = Visibility.Collapsed;
             OptionDto option = new OptionDto();
 
             if(!string.IsNullOrEmpty(txtName.Text))
@@ -75,6 +81,7 @@ namespace AutoTest.Desktop.Pages.OptionForPage
                 component.SetValues(option);
                 stOptions.Children.Add(component);
                 options.Add(option);
+                Clear();
             }
             else
             {

--- a/AutoTest.Desktop/Windows/QuestionForWIndows/CreateQuestionWindow.xaml.cs
+++ b/AutoTest.Desktop/Windows/QuestionForWIndows/CreateQuestionWindow.xaml.cs
@@ -31,6 +31,7 @@ namespace AutoTest.Desktop.Windows.QuestionForWIndows
         private long TestId { get; set; }
         private readonly IQuestionService _service;
         private readonly IOptionService _optionService;
+        public Func<Task> CreateQuestionDelegate { get; set; }
         public CreateQuestionWindow()
         {
             InitializeComponent();
@@ -137,16 +138,16 @@ namespace AutoTest.Desktop.Windows.QuestionForWIndows
                             };
 
                             var optionResult = await _optionService.AddAsync(optionDto);
-                            if(optionResult > 0)
-                            {
-                                notifier.ShowSuccess("Savol muvaffaqiyatli yaratildi.");
-                                this.Close();
-                            }
-                            else
+                            if(optionResult < 0)
                             {
                                 notifierThis.ShowError("Savol yaratishda xatolik yuz berdi!");
+                                return;
                             }
                         }
+
+                        notifier.ShowSuccess("Savol muvaffaqiyatli yaratildi!");
+                        CreateQuestionDelegate?.Invoke();
+                        this.Close();
                     }
                     else
                     {

--- a/AutoTest.Desktop/Windows/QuestionForWIndows/QuestionViewWindow.xaml.cs
+++ b/AutoTest.Desktop/Windows/QuestionForWIndows/QuestionViewWindow.xaml.cs
@@ -82,6 +82,7 @@ namespace AutoTest.Desktop.Windows.QuestionForWIndows
             CreateQuestionWindow window = new CreateQuestionWindow();
             window.SelectTestId(TestId);
             window.ShowDialog();
+            GetAllQuestion();
         }
     }
 }


### PR DESCRIPTION
- Added a private `Clear` method in `CreateOptionPage.xaml.cs` to reset input fields.
- Updated `AddOptionBtn_Click` to use `Clear` and adjust UI visibility.
- Introduced `CreateQuestionDelegate` in `CreateQuestionWindow.xaml.cs` for post-creation actions.
- Enhanced error handling and success notifications in `CreateQuestionWindow`.
- Modified `AddQuestionBtn_Click` in `QuestionViewWindow.xaml.cs` to refresh questions list after adding a new question.