### PR TITLE
Add OpenAI package reference to BLL and WebApi projects

### DIFF
--- a/AutoTest.BLL/AutoTest.BLL.csproj
+++ b/AutoTest.BLL/AutoTest.BLL.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.0" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.3.0" />
+    <PackageReference Include="OpenAI" Version="2.1.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.3.0" />
   </ItemGroup>
 

--- a/AutoTest.WebApi/AutoTest.WebApi.csproj
+++ b/AutoTest.WebApi/AutoTest.WebApi.csproj
@@ -19,6 +19,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="OpenAI" Version="2.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="7.2.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Added OpenAI library version 2.1.0 to AutoTest.BLL.csproj and AutoTest.WebApi.csproj to integrate AI capabilities such as natural language processing.