### PR TITLE
Refactor OpenAI service and update test handling

### DIFF
--- a/AutoTest.BLL/Common/Mapper/MapperProfile.cs
+++ b/AutoTest.BLL/Common/Mapper/MapperProfile.cs
@@ -44,6 +44,8 @@ public class MapperProfile : Profile
             .ForMember(dest => dest.User, opt => opt.Ignore())
             .ForMember(dest => dest.Topics, opt => opt.Ignore());
 
+        CreateMap<TestDto, CreateTestDto>();
+
         CreateMap<UpdateTestDto, Test>()
             .ForMember(dest => dest.User, opt => opt.Ignore())
             .ForMember(dest => dest.Topics, opt => opt.Ignore());

--- a/AutoTest.BLL/DTOs/Tests/Test/GenerateTestDto.cs
+++ b/AutoTest.BLL/DTOs/Tests/Test/GenerateTestDto.cs
@@ -1,0 +1,12 @@
+﻿using AutoTest.Domain.Enums;
+
+namespace AutoTest.BLL.DTOs.Tests.Test;
+
+public class GenerateTestDto
+{
+    public string Title { get; set; }
+    public string Description { get; set; }
+    public int QuestionCount { get; set; }
+    public TestLevel Level { get; set; }
+    public long UserId { get; set; }
+}

--- a/AutoTest.BLL/Interfaces/OpenAI/IOpenAIService.cs
+++ b/AutoTest.BLL/Interfaces/OpenAI/IOpenAIService.cs
@@ -1,8 +1,11 @@
-﻿using AutoTest.Domain.Entities.Users;
+﻿using AutoTest.BLL.DTOs.Tests.Test;
+using AutoTest.Domain.Entities.Users;
 
 namespace AutoTest.BLL.Interfaces.OpenAI;
 
 public interface IOpenAIService
 {
-    Task<string> GenerateTestAsync(string topic, int count, string level, long userId, CancellationToken cancellation = default);
+    Task<long> CompleteAsync(GenerateTestDto dto);
+    Task<string> GenerateAsync(GenerateTestDto dto);
+    Task<TestDto> ConvertToTest(string content, TestDto dto, long userId);
 }

--- a/AutoTest.BLL/Interfaces/Tests/Test/ITestService.cs
+++ b/AutoTest.BLL/Interfaces/Tests/Test/ITestService.cs
@@ -11,4 +11,5 @@ public interface ITestService
     Task<bool> DeleteAsync(long id, CancellationToken cancellation = default);
     Task<IEnumerable<TestDto>> GetAllCompletedAsync(CancellationToken cancellation = default); 
     Task<IEnumerable<TestDto>> GetAllByUserIdAsync(long userId, CancellationToken cancellation = default);
+    Task<long> AddTestAsync(CreateTestDto dto, CancellationToken cancellation = default);
 }

--- a/AutoTest.BLL/Services/OpenAI/OpenAIService.cs
+++ b/AutoTest.BLL/Services/OpenAI/OpenAIService.cs
@@ -1,58 +1,168 @@
-﻿using AutoTest.BLL.Interfaces.OpenAI;
+﻿using AutoMapper;
+using AutoTest.BLL.DTOs.Tests.Question;
+using AutoTest.BLL.DTOs.Tests.Test;
+using AutoTest.BLL.Interfaces.OpenAI;
+using AutoTest.BLL.Interfaces.Tests.Question;
+using AutoTest.BLL.Interfaces.Tests.Test;
+using AutoTest.Domain.Entities.Tests;
+using AutoTest.Domain.Enums;
 using Microsoft.Extensions.Configuration;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace AutoTest.BLL.Services.OpenAI;
 
-public class OpenAIService(IHttpClientFactory httpClientFactory, IConfiguration configuration) : IOpenAIService
+public class OpenAIService(
+    ITestService testService,
+    IQuestionService questionService,
+    HttpClient client,
+    IConfiguration configuration,
+    IMapper mapper) : IOpenAIService
 {
-    private readonly HttpClient _httpClient;
-    private const string OpenAiApiUrl = "https://api.openai.com/v1/chat/completions";
+    private readonly ITestService _testService = testService;
+    private readonly IQuestionService _questionService = questionService;
+    private readonly HttpClient _client = client;
     private readonly string _apiKey = configuration["OpenAI:ApiKey"];
-    public async Task<string> GenerateTestAsync(string topic, int count, string level, long userId, CancellationToken cancellation = default)
+    private readonly IMapper _mapper = mapper;
+
+    public async Task<long> CompleteAsync(GenerateTestDto dto)
     {
         try
         {
-            var promt = $@"Generate a {level} level test on the topic of {topic}.
-                Include {count} multiple-choice questions.
-                Format the response as JSON with fields:
-                - 'Topic' (string)
-                - 'Level' (string)
-                - 'Questions' (array of objects with fields: 'Question', 'Options', and 'Answer').";
-
-            var request = new
+            if(dto != null)
             {
-                model = "gpt-3.5-turbo",
-                messages = new[]
+                var generatedTest = await GenerateAsync(dto);
+                if (!string.IsNullOrEmpty(generatedTest))
                 {
-                    new
+                    var test = new TestDto
                     {
-                        role = "system",
-                        content = promt
+                        Title = dto.Title,
+                        Description = dto.Description,
+                        Level = dto.Level,
+                        UserId = dto.UserId
+                    };
+
+                    var convertedTest = await ConvertToTest(generatedTest, test, dto.UserId);
+                    if (convertedTest != null)
+                    {
+                        var createTest = _mapper.Map<CreateTestDto>(convertedTest);
+                        var testId = await _testService.AddTestAsync(createTest);
+
+                        if (testId > 0)
+                        {
+                            var questions = convertedTest.Question;
+                            foreach (var question in questions)
+                            {
+                                question.TestId = testId;
+                                var createQuestion = _mapper.Map<CreateQuestionDto>(question);
+                                await _questionService.AddAsync(createQuestion);
+                            }
+                            return testId;
+                        }
+                        else
+                        {
+                            throw new Exception("An error occurred while saving the test.");
+                        }
                     }
-                },
-                max_tokens = 1000
-            };
-
-            var requestContent = new StringContent(JsonSerializer.Serialize(request), Encoding.UTF8, "application/json");
-            _httpClient.DefaultRequestHeaders.Add("Authorization", $"Bearer {_apiKey}");
-
-            var response = await _httpClient.PostAsync(OpenAiApiUrl, requestContent, cancellation);
-            if(response.IsSuccessStatusCode)
-            {
-                var responseContent = await response.Content.ReadAsStringAsync();
-                return responseContent;
+                    else
+                    {
+                        throw new Exception("The converted test is empty.");
+                    }
+                }
+                else
+                {
+                    throw new Exception("The generated test is empty.");
+                }
             }
             else
             {
-                throw new Exception("Error while generating test");
+                throw new Exception("The test data is empty.");
             }
         }
         catch (Exception ex)
         {
-            throw new Exception("Error while generating test", ex);
+            throw new Exception($"An error occurred while completing the test: {ex.Message}");
+        }
+    }
+    public async Task<TestDto> ConvertToTest(string content, TestDto dto, long userId)
+    {
+        try
+        {
+            if(!string.IsNullOrEmpty(content))
+            {
+                var requestBody = new
+                {
+                    model = "text-davinci-003",
+                    prompt = $"Convert the following {content} into a structured {dto} object. " +
+                        $"Include Title, Description, Level, Status, and a list of questions. Each question should be mapped into a QuestionDto with Problem, Type, and Options (with IsCorrect flag). Exclude Id, CreatedDate, and UpdatedDate.",
+                    max_tokens = 300,
+                    temperature = 0.5
+                };
+
+                var request = new StringContent(JsonSerializer.Serialize(requestBody), Encoding.UTF8, "application/json");
+                _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _apiKey);
+
+                var response = await _client.PostAsync("https://api.openai.com/v1/completions", request);
+
+                if (!response.IsSuccessStatusCode)
+                {
+                    var error = await response.Content.ReadAsStringAsync();
+                    throw new Exception($"OpenAI API error : {error}");
+                }
+
+                var responseContent = await response.Content.ReadAsStringAsync();
+                var result = JsonSerializer.Deserialize<string>(responseContent);
+
+                var test = _mapper.Map<TestDto>(result);
+
+                return test;
+            }
+            else
+            {
+                throw new Exception("The generated test is empty.");
+            }
+        }
+        catch(Exception ex)
+        {
+            throw new Exception($"An error occurred while converting the generated test: {ex.Message}");
+        }
+    }
+
+    public async Task<string> GenerateAsync(GenerateTestDto dto)
+    {
+        try
+        {
+            var requestBody = new
+            {
+                model = "text-davinci-003",
+                prompt = $"Generate a test on {dto.Title} with {dto.QuestionCount} questions of {dto.Level} level.",
+                max_tokens = 300,
+                temperature = 0.5
+            };
+
+            var request = new StringContent(JsonSerializer.Serialize(requestBody), Encoding.UTF8, "application/json");
+
+            _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _apiKey);
+
+            var response = await _client.PostAsync("https://api.openai.com/v1/completions", request);
+
+            if(!response.IsSuccessStatusCode)
+            {
+                var error = await response.Content.ReadAsStringAsync();
+                throw new Exception($"OpenAI API error : {error}");
+            }
+
+            var responseContent = await response.Content.ReadAsStringAsync();
+            var result = JsonSerializer.Deserialize<string>(responseContent);
+
+            return result;
+        }
+        catch(Exception ex)
+        {
+            throw new Exception($"An error occurred while generating the test: {ex.Message}");
         }
     }
 }

--- a/AutoTest.BLL/Services/Tests/Test/TestService.cs
+++ b/AutoTest.BLL/Services/Tests/Test/TestService.cs
@@ -47,6 +47,36 @@ public class TestService(
         }
     }
 
+    public async Task<long> AddTestAsync(CreateTestDto dto, CancellationToken cancellation = default)
+    {
+        try
+        {
+            var existsUser = await _unitOfWork.User.GetById(dto.UserId);
+            if (existsUser is null)
+                throw new StatusCodeException(HttpStatusCode.NotFound, "User not found");
+
+            var test = _mapper.Map<CT.Test>(dto);
+            foreach (var topicId in dto.Topics)
+            {
+                var topic = await _unitOfWork.Topic.GetById(topicId);
+
+                if (topic is not null)
+                    test.Topics.Add(topic);
+                else
+                    break;
+            }
+
+            test.CreatedDate = DateTime.UtcNow.AddHours(5);
+            var result = await _unitOfWork.Test.AddAsync(test);
+
+            return result;
+        }
+        catch (Exception ex)
+        {
+            throw new Exception($"An error occured while creating the test. {ex}");
+        }
+    }
+
     public async Task<bool> DeleteAsync(long id, CancellationToken cancellation = default)
     {
         try

--- a/AutoTest.WebApi/AutoTest.WebApi.csproj
+++ b/AutoTest.WebApi/AutoTest.WebApi.csproj
@@ -20,6 +20,7 @@
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="OpenAI" Version="2.1.0" />
+    <PackageReference Include="OpenAI.Net" Version="1.0.4" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="7.2.0" />
   </ItemGroup>
 

--- a/AutoTest.WebApi/Configurations/LayerConfiguration.cs
+++ b/AutoTest.WebApi/Configurations/LayerConfiguration.cs
@@ -1,9 +1,11 @@
 ﻿using AutoTest.BLL.Interfaces.Auth;
+using AutoTest.BLL.Interfaces.OpenAI;
 using AutoTest.BLL.Interfaces.Tests.Option;
 using AutoTest.BLL.Interfaces.Tests.Question;
 using AutoTest.BLL.Interfaces.Tests.Test;
 using AutoTest.BLL.Interfaces.Tests.Topic;
 using AutoTest.BLL.Services.Auth;
+using AutoTest.BLL.Services.OpenAI;
 using AutoTest.BLL.Services.Tests.Option;
 using AutoTest.BLL.Services.Tests.Question;
 using AutoTest.BLL.Services.Tests.Test;
@@ -43,6 +45,8 @@ public static class LayerConfiguration
         services.AddScoped<ITopicService, TopicService>();
         services.AddScoped<IQuestionService, QuestionService>();
         services.AddScoped<IOptionService, OptionService>();
+
+        services.AddHttpClient<IOpenAIService, OpenAIService>();
 
         return services;
     }


### PR DESCRIPTION
Significant updates to OpenAI service and related interfaces:
- Updated `MapperProfile` to map `TestDto` to `CreateTestDto`.
- Modified `IOpenAIService` interface:
  - Removed `GenerateTestAsync`.
  - Added `CompleteAsync`, `GenerateAsync`, and `ConvertToTest`.
- Updated `ITestService` interface to include `AddTestAsync`.
- Refactored `OpenAIService`:
  - Updated dependencies.
  - Removed `GenerateTestAsync`.
  - Added `CompleteAsync`, `ConvertToTest`, and `GenerateAsync`.
- Updated `TestService` to include `AddTestAsync`.
- Added `GenerateTestDto` class.
- Updated `AutoTest.WebApi.csproj` to include `OpenAI.Net`.
- Updated `LayerConfiguration` to configure `IOpenAIService` and `HttpClient`.