### PR TITLE
Refactor OpenAIService to use Microsoft.SemanticKernel

### DIFF
--- a/AutoTest.BLL/Services/OpenAI/OpenAIService.cs
+++ b/AutoTest.BLL/Services/OpenAI/OpenAIService.cs
@@ -4,10 +4,9 @@ using AutoTest.BLL.DTOs.Tests.Test;
 using AutoTest.BLL.Interfaces.OpenAI;
 using AutoTest.BLL.Interfaces.Tests.Question;
 using AutoTest.BLL.Interfaces.Tests.Test;
-using Microsoft.Extensions.Configuration;
-using System.Net.Http.Headers;
-using System.Text;
-using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.ChatCompletion;
 
 namespace AutoTest.BLL.Services.OpenAI;
 
@@ -15,22 +14,19 @@ public class OpenAIService : IOpenAIService
 {
     private readonly ITestService _testService;
     private readonly IQuestionService _questionService;
-    private readonly HttpClient _client;
-    private readonly string _apiKey;
+    private readonly Kernel _kernel;
     private readonly IMapper _mapper;
 
     public OpenAIService(
         ITestService testService,
         IQuestionService questionService,
-        HttpClient client,
-        IConfiguration configuration,
+        Kernel kernel,
         IMapper mapper)
     {
         _testService = testService;
         _questionService = questionService;
-        _client = client;
-        _apiKey = configuration["OpenAI:ApiKey"];
         _mapper = mapper;
+        _kernel = kernel;
     }
 
     public async Task<long> CompleteAsync(GenerateTestDto dto)
@@ -85,63 +81,27 @@ public class OpenAIService : IOpenAIService
             throw new ArgumentException("The generated test content is empty.", nameof(content));
         }
 
-        var requestBody = new
+        var chatCompletion = _kernel.Services.GetRequiredService<IChatCompletionService>();
+        var chatMessages = new ChatHistory
         {
-            model = "gpt-4o-mini",
-            messages = new[]
-            {
-                new { role = "developer", content = "Convert the generated test to a test object." },
-                new { role = "user", content = $"Convert the following content into a structured object: {content}. Include Title, Description, Level, Status, and a list of questions. Each question should be mapped into a QuestionDto with Problem, Type, and Options (with IsCorrect flag). Exclude Id, CreatedDate, and UpdatedDate." }
-            },
-            max_tokens = 300,
-            temperature = 0.5
+            new ChatMessageContent(AuthorRole.System, "Convert the generated test into a structured TestDto object."),
+            new ChatMessageContent(AuthorRole.User, $"Convert the following content into a structured object: {content}. Include Title, Description, Level, Status, and a list of questions. Each question should be mapped into a QuestionDto with Problem, Type, and Options (with IsCorrect flag). Exclude Id, CreatedDate, and UpdatedDate.")
         };
 
-        var request = new StringContent(JsonSerializer.Serialize(requestBody), Encoding.UTF8, "application/json");
-        _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _apiKey);
-
-        var response = await _client.PostAsync("https://api.openai.com/v1/completions", request);
-
-        if (!response.IsSuccessStatusCode)
-        {
-            var error = await response.Content.ReadAsStringAsync();
-            throw new Exception($"OpenAI API error: {error}");
-        }
-
-        var responseContent = await response.Content.ReadAsStringAsync();
-        var result = JsonSerializer.Deserialize<JsonElement>(responseContent);
-        var convertedContent = result.GetProperty("choices")[0].GetProperty("text").GetString();
-
-        return _mapper.Map<TestDto>(convertedContent);
+        var response = await chatCompletion.GetChatMessageContentAsync(chatMessages);
+        return _mapper.Map<TestDto>(response?.Content);
     }
 
     public async Task<string> GenerateAsync(GenerateTestDto dto)
     {
-        var requestBody = new
+        var chatCompletion = _kernel.Services.GetRequiredService<IChatCompletionService>();
+        var chatMessages = new ChatHistory
         {
-            model = "gpt-4o-mini",
-            messages = new[]
-            {
-                new { role = "developer", content = "Generate a test." },
-                new { role = "user", content = $"Generate a test on {dto.Title} with {dto.QuestionCount} questions of {dto.Level} level." }
-            },
-            max_tokens = 300,
-            temperature = 0.5
+            new ChatMessageContent(AuthorRole.System, "Generate a test."),
+            new ChatMessageContent(AuthorRole.User, $"Generate a test on {dto.Title} with {dto.QuestionCount} questions of {dto.Level} level.")
         };
 
-        var request = new StringContent(JsonSerializer.Serialize(requestBody), Encoding.UTF8, "application/json");
-        _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _apiKey);
-
-        var response = await _client.PostAsync("https://api.openai.com/v1/chat/completions", request);
-
-        if (!response.IsSuccessStatusCode)
-        {
-            var error = await response.Content.ReadAsStringAsync();
-            throw new Exception($"OpenAI API error: {error}");
-        }
-
-        var responseContent = await response.Content.ReadAsStringAsync();
-        var result = JsonSerializer.Deserialize<JsonElement>(responseContent);
-        return result.GetProperty("choices")[0].GetProperty("message").GetProperty("content").GetString() ?? "No content generated.";
+        var response = await chatCompletion.GetChatMessageContentAsync(chatMessages);
+        return response?.Content ?? string.Empty;
     }
 }

--- a/AutoTest.WebApi/Configurations/LayerConfiguration.cs
+++ b/AutoTest.WebApi/Configurations/LayerConfiguration.cs
@@ -17,6 +17,7 @@ using AutoTest.DAL.Repotories;
 using Codeblaze.SemanticKernel.Connectors.Ollama;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.ChatCompletion;
 
 namespace AutoTest.WebApi.Configurations;
 
@@ -48,7 +49,7 @@ public static class LayerConfiguration
         services.AddScoped<IQuestionService, QuestionService>();
         services.AddScoped<IOptionService, OptionService>();
 
-        services.AddHttpClient<IOpenAIService, OpenAIService>();
+        services.AddScoped<IOpenAIService, OpenAIService>();
 
         return services;
     }
@@ -57,15 +58,16 @@ public static class LayerConfiguration
         this IServiceCollection services,
         IConfiguration configuration)
     {
-        var builder = Kernel.CreateBuilder().AddOllamaChatCompletion(
-            configuration["Kernel:Model"],
-            configuration["Kernel:localhost"]);
-
-        services.AddSingleton<HttpClient>();
+        var builder = Kernel.CreateBuilder()
+            .AddOllamaChatCompletion(
+                configuration["Kernel:Model"],
+                configuration["Kernel:localhost"]);
 
         var kernel = builder.Build();
 
         services.AddSingleton(kernel);
+        services.AddSingleton<IChatCompletionService>(sp =>
+            sp.GetRequiredService<Kernel>().GetRequiredService<IChatCompletionService>());
 
         return services;
     }

--- a/AutoTest.WebApi/Program.cs
+++ b/AutoTest.WebApi/Program.cs
@@ -9,6 +9,7 @@ builder.Services.AddControllers()
         options.SerializerSettings.ReferenceLoopHandling = Newtonsoft.Json.ReferenceLoopHandling.Ignore;
     });
 
+builder.Services.AddHttpClient();
 
 builder.Services
     .AddDbConfigure(builder.Configuration)


### PR DESCRIPTION
Refactored `OpenAIService` to utilize `Microsoft.SemanticKernel` library instead of `HttpClient` for API calls to OpenAI. This includes:
- Removed `HttpClient` and `IConfiguration` dependencies.
- Added dependency on `Kernel` from `Microsoft.SemanticKernel`.
- Replaced manual HTTP requests with `IChatCompletionService` calls.

Updated `LayerConfiguration` to:
- Remove `AddHttpClient` call for `IOpenAIService`.
- Add `IChatCompletionService` to the service collection.
- Adjust `Kernel` builder configuration to use `OllamaChatCompletion`.

Updated `Program.cs` to add `HttpClient` to the service collection using `builder.Services.AddHttpClient()`.