### PR TITLE
Refactor Question methods to use synchronous queries

### DIFF
--- a/AutoTest.BLL/Services/Tests/Question/QuestionService.cs
+++ b/AutoTest.BLL/Services/Tests/Question/QuestionService.cs
@@ -56,7 +56,7 @@ public class QuestionService(
     {
         try
         {
-            var questions = await _unitOfWork.Question.GetAllFullInformationAsync();
+            var questions = await _unitOfWork.Question.GetAllFullInformation().ToListAsync();
 
             if (!questions.Any())
                 throw new StatusCodeException(HttpStatusCode.NotFound, "No questions found");
@@ -94,9 +94,9 @@ public class QuestionService(
             if (existsTest is null)
                 throw new StatusCodeException(HttpStatusCode.NotFound, "Test not found");
 
-            var questions = await _unitOfWork.Question.GetAll()
+            var questions = _unitOfWork.Question.GetAllFullInformation()
                 .Where(x => x.TestId == testId)
-                .ToListAsync(cancellation);
+                .ToList();
 
             if(!questions.Any())
             {

--- a/AutoTest.DAL/Interfaces/Tests/IQuestion.cs
+++ b/AutoTest.DAL/Interfaces/Tests/IQuestion.cs
@@ -4,5 +4,5 @@ namespace AutoTest.DAL.Interfaces.Tests;
 
 public interface IQuestion : IRepository<Question>
 {
-    Task<List<Question>> GetAllFullInformationAsync();
+    IQueryable<Question> GetAllFullInformation();
 }

--- a/AutoTest.DAL/Repotories/Tests/QuestionRepository.cs
+++ b/AutoTest.DAL/Repotories/Tests/QuestionRepository.cs
@@ -15,11 +15,10 @@ public class QuestionRepository : Repository<Question>, IQuestion
         _questions = context.Set<Question>();
     }
 
-    public async Task<List<Question>> GetAllFullInformationAsync()
+    public IQueryable<Question> GetAllFullInformation()
     {
-        return await _questions
+        return _questions
             .Include(x => x.Test)
-            .Include(x => x.Options)
-            .ToListAsync();
+            .Include(x => x.Options);
     }
 }


### PR DESCRIPTION
Replaced async GetAllFullInformationAsync with sync GetAllFullInformation in IQuestion interface. Updated QuestionRepository to implement sync GetAllFullInformation returning IQueryable<Question>. Modified QuestionService to use new GetAllFullInformation and convert results to lists asynchronously and synchronously. Shifted list conversion responsibility from repository to service layer.