### PR TITLE
Add UpdateOptionPage and enhance option handling

### DIFF
--- a/AutoTest.Desktop/Pages/OptionForPage/CreateOptionPage.xaml.cs
+++ b/AutoTest.Desktop/Pages/OptionForPage/CreateOptionPage.xaml.cs
@@ -1,20 +1,7 @@
 ﻿using AutoTest.BLL.DTOs.Tests.Option;
 using AutoTest.Desktop.Components.OptionForComponents;
-using AutoTest.Domain.Entities.Tests;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
 using ToastNotifications;
 using ToastNotifications.Lifetime;
 using ToastNotifications.Messages;
@@ -69,6 +56,7 @@ namespace AutoTest.Desktop.Pages.OptionForPage
         {
             if (questionOptions.Any())
             {
+                EmptyData.Visibility = Visibility.Collapsed;
                 foreach (var option in questionOptions)
                 {
                     options.Add(option);

--- a/AutoTest.Desktop/Pages/OptionForPage/UpdateOptionPage.xaml
+++ b/AutoTest.Desktop/Pages/OptionForPage/UpdateOptionPage.xaml
@@ -1,0 +1,65 @@
+﻿<Page x:Class="AutoTest.Desktop.Pages.OptionForPage.UpdateOptionPage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+      xmlns:local="clr-namespace:AutoTest.Desktop.Pages.OptionForPage"
+      mc:Ignorable="d" 
+      Title="UpdateOptionPage">
+
+    <Grid>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*"/>
+            <ColumnDefinition Width="*"/>
+        </Grid.ColumnDefinitions>
+        <StackPanel Grid.Column="0">
+            <Label 
+            Content="Javob"
+            FontSize="14"
+            Style="{DynamicResource Label}"/>
+
+            <Border
+            Height="60"
+            BorderThickness="1"
+            BorderBrush="#344e41"
+            CornerRadius="5"
+            Margin="0 0 0 10">
+                <TextBox x:Name="txtName"
+                     BorderThickness="0"
+                     Margin="5 0"
+                     TextWrapping="Wrap"
+                     Background="Transparent"
+                     FontSize="18"
+                     VerticalContentAlignment="Center"/>
+            </Border>
+
+            <RadioButton x:Name="rbIsCorrect"
+                     Content="To'g'ri javobni belgilang"
+                     FontSize="14"
+                     FontFamily="Jetbrains Mono"
+                     FontWeight="SemiBold"/>
+
+            <Button x:Name="AddOptionBtn"
+                Content="Javobni qo'shish"
+                Style="{DynamicResource mainButton}"
+                Background="#2196F3"
+                Width="100"
+                Height="30"
+                Margin="0 5"
+                Click="AddOptionBtn_Click"/>
+        </StackPanel>
+
+        <Grid Grid.Column="1">
+            <Label x:Name="EmptyData"
+               Content="Javoblar yo'q!"
+               Style="{DynamicResource Label}"
+               HorizontalAlignment="Center"
+               VerticalAlignment="Center"/>
+            <ScrollViewer Margin="0 5">
+                <StackPanel
+                        x:Name="stOptions"
+                        Margin="5 0"/>
+            </ScrollViewer>
+        </Grid>
+    </Grid>
+</Page>

--- a/AutoTest.Desktop/Pages/OptionForPage/UpdateOptionPage.xaml.cs
+++ b/AutoTest.Desktop/Pages/OptionForPage/UpdateOptionPage.xaml.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace AutoTest.Desktop.Pages.OptionForPage
+{
+    /// <summary>
+    /// Interaction logic for UpdateOptionPage.xaml
+    /// </summary>
+    public partial class UpdateOptionPage : Page
+    {
+        public UpdateOptionPage()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/AutoTest.Desktop/Windows/QuestionForWIndows/UpdateQuestionWindow.xaml.cs
+++ b/AutoTest.Desktop/Windows/QuestionForWIndows/UpdateQuestionWindow.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using AutoTest.BLL.DTOs.Tests.Question;
 using AutoTest.Desktop.Pages.OptionForPage;
+using AutoTest.Domain.Enums;
 using System.Windows;
 using ToastNotifications;
 using ToastNotifications.Lifetime;
@@ -61,6 +62,7 @@ namespace AutoTest.Desktop.Windows.QuestionForWIndows
             {
                 Question = dto;
                 PageNavigator();
+                Get(dto.Problem, dto.Type);
             }
             else
             {
@@ -74,6 +76,25 @@ namespace AutoTest.Desktop.Windows.QuestionForWIndows
             CreateOptionPage page = new CreateOptionPage();
             page.AddOptions(Question.Options);
             OptionPageNavigator.Content = page;
+        }
+
+        private void Get(string problem, QuestionType type)
+        {
+            if (!string.IsNullOrEmpty(problem))
+            {
+                txtProblem.Text = problem;
+
+                var questionType = type switch
+                {
+                    QuestionType.Multiple => rbMultiple.IsChecked = true,
+                    QuestionType.FIllInTheBlank => rbFillInTheBlank.IsChecked = true,
+                    QuestionType.TrueFalse => rbTrueOrFalse.IsChecked = true,
+                    _ => false
+                };
+
+                if (questionType == false)
+                    notifierThis.ShowWarning("Savol turi tanlanmagan!");
+            }
         }
 
         private void CloseBtn_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
Add UpdateOptionPage and enhance option handling

- Remove unused `using` directives and hide `EmptyData` in `CreateOptionPage.xaml.cs`
- Add `using AutoTest.Domain.Enums` and new `Get` method in `UpdateQuestionWindow.xaml.cs`
- Create `UpdateOptionPage.xaml` with layout for input fields and options
- Add `UpdateOptionPage.xaml.cs` with necessary `using` directives and constructor