### PR TITLE
Add UpdateAsync method to OptionServer and OptionService

### DIFF
--- a/AutoTest.Desktop.Integrated/Servers/Interfaces/Option/IOptionServer.cs
+++ b/AutoTest.Desktop.Integrated/Servers/Interfaces/Option/IOptionServer.cs
@@ -6,4 +6,5 @@ public interface IOptionServer
 {
     Task<List<OptionDto>> GetAllAsync();
     Task<long> AddAsync(CreateOptionDto dto);
+    Task<bool> UpdateAsync(long id, UpdateOptionDto dto);
 }

--- a/AutoTest.Desktop.Integrated/Servers/Repositories/Option/OptionServer.cs
+++ b/AutoTest.Desktop.Integrated/Servers/Repositories/Option/OptionServer.cs
@@ -2,7 +2,6 @@
 using AutoTest.Desktop.Integrated.Api.Auth;
 using AutoTest.Desktop.Integrated.Security;
 using AutoTest.Desktop.Integrated.Servers.Interfaces.Option;
-using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Newtonsoft.Json;
 using System.Text;
 
@@ -46,5 +45,31 @@ public class OptionServer : IOptionServer
     public Task<List<OptionDto>> GetAllAsync()
     {
         throw new NotImplementedException();
+    }
+
+    public async Task<bool> UpdateAsync(long id, UpdateOptionDto dto)
+    {
+        try
+        {
+            HttpClient client = new HttpClient();
+            var token = IdentitySingelton.GetInstance().Token;
+
+            var url = $"{AuthApi.BASE_URL}/api/options/{id}";
+            var request = new HttpRequestMessage(HttpMethod.Put, url);
+            request.Headers.Add("Authorization", $"Bearer {token}");
+
+            var json = new StringContent(JsonConvert.SerializeObject(dto), Encoding.UTF8, "application/json");
+            request.Content = json;
+
+            var response = await client.SendAsync(request);
+            if (response.IsSuccessStatusCode)
+                return true;
+            else
+                return false;
+        }
+        catch(Exception ex)
+        {
+            return false;
+        }
     }
 }

--- a/AutoTest.Desktop.Integrated/Services/Option/IOptionService.cs
+++ b/AutoTest.Desktop.Integrated/Services/Option/IOptionService.cs
@@ -5,4 +5,5 @@ namespace AutoTest.Desktop.Integrated.Services.Option;
 public interface IOptionService
 {
     Task<long> AddAsync(CreateOptionDto dto);
+    Task<bool> UpdateAsync(long id, UpdateOptionDto dto);
 }

--- a/AutoTest.Desktop.Integrated/Services/Option/OptionService.cs
+++ b/AutoTest.Desktop.Integrated/Services/Option/OptionService.cs
@@ -31,6 +31,26 @@ public class OptionService : IOptionService
         }
     }
 
+    public async Task<bool> UpdateAsync(long id, UpdateOptionDto dto)
+    {
+        try
+        {
+            if (IsInternetAvailable())
+            {
+                var res = await _server.UpdateAsync(id, dto);
+                return res;
+            }
+            else
+            {
+                return false;
+            }
+        }
+        catch(Exception ex)
+        {
+            return false;
+        }
+    }
+
     private bool IsInternetAvailable()
     {
         try

--- a/AutoTest.Desktop/Windows/QuestionForWIndows/UpdateQuestionWindow.xaml.cs
+++ b/AutoTest.Desktop/Windows/QuestionForWIndows/UpdateQuestionWindow.xaml.cs
@@ -177,7 +177,7 @@ namespace AutoTest.Desktop.Windows.QuestionForWIndows
                                         IsChange = option.IsChange
                                     };
 
-                                    //optionRes = await _optionService.UpdateAsync(option.Id, optionDto);
+                                    optionRes = await _optionService.UpdateAsync(option.Id, optionDto);
                                 }
                             }
 


### PR DESCRIPTION
Updated IOptionServer and IOptionService interfaces to include UpdateAsync method. Implemented UpdateAsync in OptionServer to send HTTP PUT requests with authorization. Implemented UpdateAsync in OptionService to check internet availability before calling OptionServer. Uncommented UpdateAsync call in UpdateQuestionWindow.