### PR TITLE
Add methods to fetch tests by topic ID across layers

### DIFF
--- a/AutoTest.BLL/Interfaces/Tests/Test/ITestService.cs
+++ b/AutoTest.BLL/Interfaces/Tests/Test/ITestService.cs
@@ -11,5 +11,6 @@ public interface ITestService
     Task<bool> DeleteAsync(long id, CancellationToken cancellation = default);
     Task<IEnumerable<TestDto>> GetAllCompletedAsync(CancellationToken cancellation = default); 
     Task<IEnumerable<TestDto>> GetAllByUserIdAsync(long userId, CancellationToken cancellation = default);
+    Task<IEnumerable<TestDto>> GetAllByTopicIdAsync(long topicId, CancellationToken cancellation = default);    
     Task<long> AddTestAsync(CreateTestDto dto, CancellationToken cancellation = default);
 }

--- a/AutoTest.BLL/Services/Tests/Test/TestService.cs
+++ b/AutoTest.BLL/Services/Tests/Test/TestService.cs
@@ -112,6 +112,28 @@ public class TestService(
         }
     }
 
+    public async Task<IEnumerable<TestDto>> GetAllByTopicIdAsync(long topicId, CancellationToken cancellation = default)
+    {
+        try
+        {
+            var tests = await _unitOfWork.Test.GetAllFullInformationAsync();
+
+            if(!tests.Any())
+                throw new StatusCodeException(HttpStatusCode.NotFound, "No tests found");
+
+            var results = tests.Where(x => x.Topics.Any(y => y.Id == topicId)).ToList();
+
+            if (!results.Any())
+                throw new StatusCodeException(HttpStatusCode.NoContent, "No tests found on the topic");
+
+            return _mapper.Map<IEnumerable<TestDto>>(results);
+        }
+        catch (Exception ex)
+        {
+            throw new Exception($"An error occured while getting all tests by topic id. {ex}");
+        }
+    }
+
     public async Task<IEnumerable<TestDto>> GetAllByUserIdAsync(long userId, CancellationToken cancellation = default)
     {
         try

--- a/AutoTest.Desktop.Integrated/Servers/Interfaces/Test/ITestServer.cs
+++ b/AutoTest.Desktop.Integrated/Servers/Interfaces/Test/ITestServer.cs
@@ -11,4 +11,5 @@ public interface ITestServer
     Task<bool> DeleteAsync(long id);
     Task<List<TestDto>> CompletedTaskAsync();
     Task<List<TestDto>> GetAllByUserIdAsync(long userId);
+    Task<List<TestDto>> GetAllByTopicIdAsync(long topicId);
 }

--- a/AutoTest.Desktop.Integrated/Servers/Repositories/Test/TestServer.cs
+++ b/AutoTest.Desktop.Integrated/Servers/Repositories/Test/TestServer.cs
@@ -115,6 +115,29 @@ public class TestServer : ITestServer
         }
     }
 
+    public async Task<List<TestDto>> GetAllByTopicIdAsync(long topicId)
+    {
+        try
+        {
+            HttpClient client = new HttpClient();
+            var token = IdentitySingelton.GetInstance().Token;
+
+            client.BaseAddress = new Uri($"{AuthApi.BASE_URL}/api/tests/{topicId}/topic");
+            client.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
+            HttpResponseMessage message = await client.GetAsync(client.BaseAddress);
+
+            string response = await message.Content.ReadAsStringAsync();
+
+            List<TestDto> tests = JsonConvert.DeserializeObject<List<TestDto>>(response)!;
+
+            return tests;
+        }
+        catch(Exception ex)
+        {
+            return new List<TestDto>();
+        }
+    }
+
     public async Task<List<TestDto>> GetAllByUserIdAsync(long userId)
     {
         try

--- a/AutoTest.Desktop.Integrated/Services/Test/ITestService.cs
+++ b/AutoTest.Desktop.Integrated/Services/Test/ITestService.cs
@@ -11,4 +11,5 @@ public interface ITestService
     Task<bool> DeleteAsync(long id);
     Task<List<TestDto>> CompletedTaskAsync();
     Task<List<TestDto>> GetAllByUserIdAsync(long userId);
+    Task<List<TestDto>> GetAllByTopicIdAsync(long topicId);
 }

--- a/AutoTest.Desktop.Integrated/Services/Test/TestService.cs
+++ b/AutoTest.Desktop.Integrated/Services/Test/TestService.cs
@@ -1,8 +1,6 @@
 ﻿using AutoTest.BLL.DTOs.Tests.Test;
 using AutoTest.Desktop.Integrated.Servers.Interfaces.Test;
 using AutoTest.Desktop.Integrated.Servers.Repositories.Test;
-using System.Net.NetworkInformation;
-using System.Runtime.CompilerServices;
 
 namespace AutoTest.Desktop.Integrated.Services.Test;
 
@@ -69,6 +67,24 @@ public class TestService : ITestService
                 return new List<TestDto>();
         }
         catch(Exception ex)
+        {
+            return new List<TestDto>();
+        }
+    }
+
+    public async Task<List<TestDto>> GetAllByTopicIdAsync(long topicId)
+    {
+        try
+        {
+            if (IsInternetAvailable())
+            {
+                var tests = await _server.GetAllByTopicIdAsync(topicId);
+                return tests;
+            }
+            else
+                return new List<TestDto>();
+        }
+        catch (Exception ex)
         {
             return new List<TestDto>();
         }

--- a/AutoTest.WebApi/Controllers/Common/Test/TestController.cs
+++ b/AutoTest.WebApi/Controllers/Common/Test/TestController.cs
@@ -84,6 +84,23 @@ public class TestController(ITestService service) : ControllerBase
         }
     }
 
+    [HttpGet("{topicId:long}/topic")]
+    public async Task<IActionResult> GetAllByTopicIdAsync(long topicId, CancellationToken cancellation = default)
+    {
+        try
+        {
+            var response = await _service.GetAllByTopicIdAsync(topicId, cancellation);
+            return Ok(response);
+        }
+        catch (StatusCodeException ex)
+        {
+            return StatusCode((int)ex.StatusCode, ex.Message);
+        }
+        catch (Exception ex)
+        {
+            return StatusCode(StatusCodes.Status500InternalServerError, ex.Message);
+        }
+    }
 
     [HttpPost]
     public async Task<IActionResult> CreateAsync([FromBody] CreateTestDto dto, CancellationToken cancellation = default)


### PR DESCRIPTION
Introduced `GetAllByTopicIdAsync` method in `ITestService` and `ITestServer` interfaces, and implemented it in `TestService` and `TestServer` classes. Added a new HTTP GET endpoint in `TestController` to fetch tests by topic ID. Implemented exception handling and internet availability checks.