### PR TITLE
Add GetAllByTopicIdAsync method and update related logic

### DIFF
--- a/AutoTest.BLL/Interfaces/Tests/Test/ITestService.cs
+++ b/AutoTest.BLL/Interfaces/Tests/Test/ITestService.cs
@@ -12,4 +12,5 @@ public interface ITestService
     Task<IEnumerable<TestDto>> GetAllCompletedAsync(CancellationToken cancellation = default);
     Task<IEnumerable<TestDto>> GetAllByUserIdAsync(long userId, CancellationToken cancellation = default);
     Task<long> AddTestAsync(CreateTestDto dto, CancellationToken cancellation = default);
+    Task<IEnumerable<TestDto>> GetAllByTopicIdAsync(long topicId, CancellationToken cancellation = default);
 }

--- a/AutoTest.BLL/Services/Tests/Test/TestService.cs
+++ b/AutoTest.BLL/Services/Tests/Test/TestService.cs
@@ -112,6 +112,24 @@ public class TestService(
         }
     }
 
+    public async Task<IEnumerable<TestDto>> GetAllByTopicIdAsync(long topicId, CancellationToken cancellation = default)
+    {
+        try
+        {
+            var tests = await _unitOfWork.Test.GetAllFullInformationAsync();
+
+            if(!tests.Any())
+                throw new StatusCodeException(HttpStatusCode.NotFound, "No tests found");
+
+            var results = tests.Where(x => x.Topics.Any(y => y.Id == topicId)).ToList();
+            return _mapper.Map<IEnumerable<TestDto>>(results);
+        }
+        catch(Exception ex)
+        {
+            throw new Exception($"An error occured while getting all tests by topic id. {ex}");
+        }
+    }
+
     public async Task<IEnumerable<TestDto>> GetAllByUserIdAsync(long userId, CancellationToken cancellation = default)
     {
         try

--- a/AutoTest.Desktop/Pages/MainForPage/MainPage.xaml.cs
+++ b/AutoTest.Desktop/Pages/MainForPage/MainPage.xaml.cs
@@ -89,16 +89,16 @@ namespace AutoTest.Desktop.Pages.MainForPage
             }
         }
 
-        private async Task GetAllByTopicAsync()
+        private async Task GetAllByTopicAsync(long topicId)
         {
-            st_tests.Children.Clear();
             TestLoader.Visibility = Visibility.Visible;
             if (IsInternetAvailable())
             {
-                var tests = await Task.Run(async () => await _testService.GetAllByTopicIdAsync(selectedTopicId));
+                var tests = await Task.Run(async () => await _testService.GetAllByTopicIdAsync(topicId));
                 int count = 1;
-                if (tests.Count > 0 || !tests.Any())
+                if (tests.Count > 0 || tests.Any())
                 {
+                    st_tests.Children.Clear();
                     TestLoader.Visibility = Visibility.Collapsed;
                     TestEmptyData.Visibility = Visibility.Collapsed;
                     foreach (var test in tests)
@@ -114,7 +114,7 @@ namespace AutoTest.Desktop.Pages.MainForPage
                 {
                     notifier.ShowWarning("Bu mavzuga testlar topilmadi!");
                     TestLoader.Visibility = Visibility.Collapsed;
-                    TestEmptyData.Visibility = Visibility.Visible;
+                    GetAllTest();
                 }
             }
             else
@@ -174,7 +174,7 @@ namespace AutoTest.Desktop.Pages.MainForPage
             if (selectedTopicId != component.GetId())
             {
                 selectedTopicId = component.GetId();
-                await GetAllByTopicAsync();
+                await GetAllByTopicAsync(selectedTopicId);
             }
         }
 

--- a/AutoTest.WebApi/Controllers/Common/Test/TestController.cs
+++ b/AutoTest.WebApi/Controllers/Common/Test/TestController.cs
@@ -3,6 +3,7 @@ using AutoTest.BLL.DTOs.Tests.Test;
 using AutoTest.BLL.Interfaces.Tests.Test;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.TagHelpers.Cache;
 
 namespace AutoTest.WebApi.Controllers.Common.Test;
 
@@ -84,6 +85,23 @@ public class TestController(ITestService service) : ControllerBase
         }
     }
 
+    [HttpGet("{topicId:long}/topic")]
+    public async Task<IActionResult> GetAllByTopicIdAsync(long topicId, CancellationToken cancellation = default)
+    {
+        try
+        {
+            var response = await _service.GetAllByTopicIdAsync(topicId, cancellation);
+            return Ok(response);
+        }
+        catch (StatusCodeException ex)
+        {
+            return StatusCode((int)ex.StatusCode, ex.Message);
+        }
+        catch (Exception ex)
+        {
+            return StatusCode(StatusCodes.Status500InternalServerError, ex.Message);
+        }
+    }
 
     [HttpPost]
     public async Task<IActionResult> CreateAsync([FromBody] CreateTestDto dto, CancellationToken cancellation = default)


### PR DESCRIPTION
- Updated ITestService to include GetAllByTopicIdAsync for retrieving tests by topic ID.
- Implemented GetAllByTopicIdAsync in TestService with error handling.
- Modified GetAllByTopicAsync in MainPage.xaml.cs to accept topicId parameter.
- Adjusted logic in GetAllByTopicAsync for better UI feedback.
- Added new HTTP GET endpoint in TestController for fetching tests by topic ID.