### PR TITLE
Add VerifyPasswordWindow for password verification

### DIFF
--- a/AutoTest.Desktop/Pages/AuthForPage/LoginPage.xaml
+++ b/AutoTest.Desktop/Pages/AuthForPage/LoginPage.xaml
@@ -86,6 +86,7 @@
                             Background="Transparent"
                             BorderThickness="0"
                             Width="160"
+                            MaxLength="8"
                             HorizontalAlignment="Left"
                             VerticalContentAlignment="Center"
                             FontSize="18"
@@ -100,6 +101,7 @@
                             BorderThickness="0"
                             VerticalContentAlignment="Center"
                             FontSize="18"
+                            MaxLength="8"
                             FontFamily="Jetbrains Mono"
                             FontWeight="SemiBold"
                             Foreground="Black"/>

--- a/AutoTest.Desktop/Pages/AuthForPage/RegisterPage.xaml
+++ b/AutoTest.Desktop/Pages/AuthForPage/RegisterPage.xaml
@@ -118,6 +118,7 @@
                             FontWeight="SemiBold"
                             FontSize="18"   
                             Width="160"
+                            MaxLength="8"
                             VerticalContentAlignment="Center"
                             Foreground="Black"
                             Background="Transparent"
@@ -132,6 +133,7 @@
                             BorderThickness="0"
                             VerticalContentAlignment="Center"
                             FontSize="18"
+                            MaxLength="8"
                             FontFamily="Jetbrains Mono"
                             FontWeight="SemiBold"
                             Foreground="Black"/>

--- a/AutoTest.Desktop/Pages/ProfileForPage/ProfilePage.xaml
+++ b/AutoTest.Desktop/Pages/ProfileForPage/ProfilePage.xaml
@@ -141,9 +141,11 @@
                                         <ColumnDefinition Width="*"/>
                                     </Grid.ColumnDefinitions>
                                     <Border Grid.Column="0"
+                                            x:Name="VerifyBtn"
                                             Margin="0 5 10 5"
                                             CornerRadius="5"
-                                            Background="MediumSeaGreen">
+                                            Background="MediumSeaGreen"
+                                            MouseDown="VerifyBtn_MouseDown">
                                         <Label Content="Tekshirish"
                                                FontSize="13"
                                                HorizontalAlignment="Center"

--- a/AutoTest.Desktop/Pages/ProfileForPage/ProfilePage.xaml.cs
+++ b/AutoTest.Desktop/Pages/ProfileForPage/ProfilePage.xaml.cs
@@ -81,5 +81,11 @@ namespace AutoTest.Desktop.Pages.ProfileForPage
             ChangePasswordWindow window = new ChangePasswordWindow();
             window.ShowDialog();
         }
+
+        private void VerifyBtn_MouseDown(object sender, System.Windows.Input.MouseButtonEventArgs e)
+        {
+            VerifyPasswordWindow window = new VerifyPasswordWindow();
+            window.ShowDialog();
+        }
     }
 }

--- a/AutoTest.Desktop/Windows/ProfileForWindows/VerifyPasswordWindow.xaml
+++ b/AutoTest.Desktop/Windows/ProfileForWindows/VerifyPasswordWindow.xaml
@@ -1,0 +1,69 @@
+﻿<Window x:Class="AutoTest.Desktop.Windows.ProfileForWindows.VerifyPasswordWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:AutoTest.Desktop.Windows.ProfileForWindows" xmlns:local1="clr-namespace:AutoTest.Desktop.Components.Loader"
+        mc:Ignorable="d"
+        Title="VerifyPasswordWindow"
+        Height="180" 
+        Width="400"
+        WindowStartupLocation="CenterScreen"
+        WindowStyle="None"
+        Loaded="Window_Loaded">
+    <Grid Margin="10 0">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="35"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="50"/>
+        </Grid.RowDefinitions>
+
+        <Grid Grid.Row="0">
+            <Label Content="Parolni tekshirish"
+                   Style="{DynamicResource Label}"
+                   FontSize="18"
+                   HorizontalAlignment="Left"
+                   VerticalAlignment="Center"/>
+
+            <Button x:Name="CloseBtn"
+                    Style="{DynamicResource WindowCloseBtnStyle}"
+                    HorizontalAlignment="Right"
+                    Click="CloseBtn_Click"/>
+        </Grid>
+
+        <StackPanel Grid.Row="1"
+                    VerticalAlignment="Center">
+            <Label Content="Parol"
+                   Style="{DynamicResource Label}"
+                   FontSize="14"/>
+
+            <Border Height="40"
+                    CornerRadius="5"
+                    BorderThickness="1"
+                    BorderBrush="#344e41">
+                <TextBox x:Name="PasswordTxt"
+                         Margin="5 0"
+                         MaxLength="8"
+                         BorderThickness="0"
+                         FontSize="18"
+                         VerticalContentAlignment="Center"/>
+            </Border>
+        </StackPanel>
+
+        <Grid Grid.Row="2">
+            <StackPanel VerticalAlignment="Center">
+                <Button x:Name="SubmitBtn"
+                        Content="Tekshirish"
+                        FontSize="18"
+                        Style="{DynamicResource mainButton}"
+                        Background="#588157"
+                        Click="SubmitBtn_Click"/>
+            </StackPanel>
+
+            <local1:Loader x:Name="Loader"
+                           Visibility="Collapsed"
+                           VerticalAlignment="Center"
+                           HorizontalAlignment="Center"/>
+        </Grid>
+    </Grid>
+</Window>

--- a/AutoTest.Desktop/Windows/ProfileForWindows/VerifyPasswordWindow.xaml.cs
+++ b/AutoTest.Desktop/Windows/ProfileForWindows/VerifyPasswordWindow.xaml.cs
@@ -1,0 +1,119 @@
+﻿using AutoTest.Desktop.Integrated.Security;
+using AutoTest.Desktop.Integrated.Services.User;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Shapes;
+using ToastNotifications;
+using ToastNotifications.Lifetime;
+using ToastNotifications.Messages;
+using ToastNotifications.Position;
+
+namespace AutoTest.Desktop.Windows.ProfileForWindows
+{
+    /// <summary>
+    /// Interaction logic for VerifyPasswordWindow.xaml
+    /// </summary>
+    public partial class VerifyPasswordWindow : Window
+    {
+        private readonly IUserService _service;
+        public long UserId { get; set; }
+        public VerifyPasswordWindow()
+        {
+            InitializeComponent();
+            this._service = new UserService();
+        }
+
+        Notifier notifier = new Notifier(cfg =>
+        {
+            cfg.PositionProvider = new WindowPositionProvider(
+                parentWindow: Application.Current.MainWindow,
+                corner: Corner.TopRight,
+                offsetX: 20,
+                offsetY: 20);
+
+            cfg.LifetimeSupervisor = new TimeAndCountBasedLifetimeSupervisor(
+                notificationLifetime: TimeSpan.FromSeconds(3),
+                maximumNotificationCount: MaximumNotificationCount.FromCount(2));
+
+            cfg.Dispatcher = Application.Current.Dispatcher;
+
+            cfg.DisplayOptions.Width = 200;
+            cfg.DisplayOptions.TopMost = true;
+        });
+
+        Notifier notifierThis = new Notifier(cfg =>
+        {
+            cfg.PositionProvider = new WindowPositionProvider(
+                parentWindow: Application.Current.Windows.OfType<Window>().SingleOrDefault(x => x.IsActive),
+                corner: Corner.TopRight,
+                offsetX: 20,
+                offsetY: 20);
+
+            cfg.LifetimeSupervisor = new TimeAndCountBasedLifetimeSupervisor(
+                notificationLifetime: TimeSpan.FromSeconds(3),
+                maximumNotificationCount: MaximumNotificationCount.FromCount(2));
+
+            cfg.Dispatcher = Application.Current.Dispatcher;
+
+            cfg.DisplayOptions.Width = 200;
+            cfg.DisplayOptions.TopMost = true;
+        });
+
+        private void Window_Loaded(object sender, RoutedEventArgs e)
+        {
+            this.UserId = IdentitySingelton.GetInstance().Id;
+        }
+
+        private async void SubmitBtn_Click(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                SubmitBtn.Visibility = Visibility.Collapsed;
+                Loader.Visibility = Visibility.Visible;
+
+                if(!string.IsNullOrEmpty(PasswordTxt.Text))
+                {
+                    var res = await _service.VerifyPasswordAsync(this.UserId, PasswordTxt.Text);
+
+                    if(res)
+                    {
+                        notifier.ShowSuccess("Parol to'g'ri.");
+                        this.Close();
+                    }
+                    else
+                    {
+                        notifierThis.ShowWarning("Parol noto'g'ri!");
+                        Loader.Visibility = Visibility.Collapsed;
+                        SubmitBtn.Visibility = Visibility.Visible;
+                    }
+                }
+                else
+                {
+                    notifierThis.ShowWarning("Parolni kiriting!");
+                    Loader.Visibility = Visibility.Collapsed;
+                    SubmitBtn.Visibility = Visibility.Visible;
+                }
+
+            }
+            catch(Exception ex)
+            {
+                notifierThis.ShowWarning("Xatolik yuz berdi!");
+                Loader.Visibility = Visibility.Collapsed;
+                SubmitBtn.Visibility = Visibility.Visible;
+            }
+        }
+
+        private void CloseBtn_Click(object sender, RoutedEventArgs e)
+            => this.Close();
+    }
+}


### PR DESCRIPTION
This commit introduces a new `VerifyPasswordWindow` to the application, including both XAML and code-behind files. The `MaxLength` property for `PasswordBox` elements in `LoginPage.xaml` and `RegisterPage.xaml` is set to 8 characters. A new `MouseDown` event handler in `ProfilePage.xaml` opens the `VerifyPasswordWindow`. The new window features a user interface for password verification and includes logic for handling user interactions and notifications for success or failure.