### PR TITLE
Add EmptyData label for no saved tests scenario

### DIFF
--- a/AutoTest.Desktop/Windows/TestForWindows/SavedTestWindow.xaml
+++ b/AutoTest.Desktop/Windows/TestForWindows/SavedTestWindow.xaml
@@ -38,6 +38,13 @@
                 <StackPanel x:Name="stSavedTest"
                             Margin="0 0 5 0"/>
             </ScrollViewer>
+
+            <Label x:Name="EmptyData"
+                   Content="Saqlanganlar mavjud emas!"
+                   Style="{DynamicResource Label}"
+                   HorizontalAlignment="Center"
+                   VerticalAlignment="Center"
+                   Visibility="Collapsed"/>
         </Grid>
     </Grid>
 </Window>

--- a/AutoTest.Desktop/Windows/TestForWindows/SavedTestWindow.xaml.cs
+++ b/AutoTest.Desktop/Windows/TestForWindows/SavedTestWindow.xaml.cs
@@ -47,6 +47,11 @@ public partial class SavedTestWindow : Window
                 count++;
             }
         }
+        else
+        {
+            SavedTestLoader.Visibility = Visibility.Collapsed;
+            EmptyData.Visibility = Visibility.Visible;
+        }
     }
 
     public void SetUserId(long userId)


### PR DESCRIPTION
Introduced a new `Label` control in `SavedTestWindow.xaml` to inform users when no saved items are available. Updated `SavedTestWindow.xaml.cs` to toggle the visibility of `SavedTestLoader` and the new `EmptyData` label based on the presence of saved tests.