### PR TITLE
Refactor QuestionSolutionServer and TestSolutionWindow

### DIFF
--- a/AutoTest.Desktop.Integrated/Servers/Repositories/Question/QuestionSolutionServer.cs
+++ b/AutoTest.Desktop.Integrated/Servers/Repositories/Question/QuestionSolutionServer.cs
@@ -24,7 +24,7 @@ public class QuestionSolutionServer : IQuestionSolutionServer
                 {
                     request.Headers.Add("Authorization", $"Bearer {token}");
 
-                    var json = JsonConvert.DeserializeObject(dto);
+                    var json = JsonConvert.SerializeObject(dto);
                     var content = new StringContent(json, Encoding.UTF8, "application/json");
 
                     request.Content = content;
@@ -96,12 +96,13 @@ public class QuestionSolutionServer : IQuestionSolutionServer
             HttpClient client = new HttpClient();
             var token = IdentitySingelton.GetInstance().Token;
 
-            client.BaseAddress = new Uri($"{AuthApi.BASE_URL}/api/question/solutions/{id}/test-solution");
+            client.BaseAddress = new Uri($"{AuthApi.BASE_URL}/api/question/solutions/{testSolutionId}/test-solution");
             client.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");
 
             var response = await client.GetAsync(client.BaseAddress);
+            var result = await response.Content.ReadAsStringAsync();
 
-            List<QuestionSolutionDto> questionSolutions = JsonConvert.DeserializeObject<List<QuestionSolutionDto>>(response)!;
+            List<QuestionSolutionDto> questionSolutions = JsonConvert.DeserializeObject<List<QuestionSolutionDto>>(result)!;
             return questionSolutions;
         }
         catch(Exception ex)
@@ -121,13 +122,14 @@ public class QuestionSolutionServer : IQuestionSolutionServer
             client.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");
 
             var response = await client.GetAsync(client.BaseAddress);
+            string result = await response.Content.ReadAsStringAsync();
 
-            var questionSolution = JsonConvert.DeserializeObject<QuestionSolutionDto>(response)!;
+            var questionSolution = JsonConvert.DeserializeObject<QuestionSolutionDto>(result)!;
             return questionSolution;
         }
         catch(Exception ex)
         {
-            return new List<QuestionSolutionDto>();
+            return new QuestionSolutionDto();
         }
     }
 

--- a/AutoTest.Desktop/Windows/TestForWindows/TestSolutionWindow.xaml.cs
+++ b/AutoTest.Desktop/Windows/TestForWindows/TestSolutionWindow.xaml.cs
@@ -17,8 +17,8 @@ public partial class TestSolutionWindow : Window
     private void CloseBtn_Click(object sender, RoutedEventArgs e)
         => this.Close();
 
-    public void SetTestId()
-        => this.TestId = TestId;
+    public void SetTestId(long testId)
+        => this.TestId = testId;
 
     private void StartBtn_Click(object sender, RoutedEventArgs e)
     {


### PR DESCRIPTION
Updated JSON handling in QuestionSolutionServer to serialize the dto object before sending requests. Changed base address to use testSolutionId and adjusted response processing. Modified the catch block to return a single QuestionSolutionDto. In TestSolutionWindow, SetTestId now accepts a testId parameter for improved clarity and usability.